### PR TITLE
Allow entering bundle keys partially

### DIFF
--- a/src/key_match.rs
+++ b/src/key_match.rs
@@ -1,0 +1,67 @@
+// All Humble Bundle bundle keys have this length
+const FULL_KEY_SIZE: usize = 16;
+
+pub struct KeyMatch {
+    keys: Vec<String>,
+    target: String,
+}
+
+impl KeyMatch {
+    pub fn new(keys: Vec<String>, target: &str) -> Self {
+        Self {
+            keys,
+            target: target.to_lowercase(),
+        }
+    }
+
+    fn is_full_key(key: &str) -> bool {
+        key.len() == FULL_KEY_SIZE
+    }
+
+    /// Perform a case-insensitive search and find any key that starts with
+    /// the given `target` value.
+    ///
+    /// If `target` is already a full bundle key and not a partial key, then
+    /// the `target` will be returned without any search.
+    pub fn get_matches(&self) -> Vec<String> {
+        if Self::is_full_key(&self.target) {
+            return vec![self.target.clone()];
+        }
+
+        self.keys
+            .iter()
+            .filter(|k| k.to_lowercase().starts_with(&self.target))
+            .map(|k| k.clone())
+            .collect()
+    }
+}
+
+#[test]
+fn test_single_match() {
+    let keys = vec!["1aAa".to_owned(), "2bbbb".to_owned()];
+    let target = "1a".to_owned();
+
+    let key_match = KeyMatch::new(keys, &target);
+    assert_eq!(key_match.get_matches(), vec!["1aAa".to_owned()]);
+}
+
+#[test]
+fn test_no_match() {
+    let keys = vec!["1aaa".to_owned(), "2bbbb".to_owned()];
+    let target = "3c".to_owned();
+
+    let key_match = KeyMatch::new(keys, &target);
+    assert!(key_match.get_matches().is_empty());
+}
+
+#[test]
+fn test_multiple_matches() {
+    let keys = vec!["1aaa".to_owned(), "1aXXX".to_owned(), "2bbbb".to_owned()];
+    let target = "1a".to_owned();
+
+    let key_match = KeyMatch::new(keys, &target);
+    assert_eq!(
+        key_match.get_matches(),
+        vec!["1aaa".to_owned(), "1aXXX".to_owned()]
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,18 +43,24 @@ pub fn run() -> Result<(), anyhow::Error> {
     let details_subcommand = Command::new("details")
         .about("Print details of a certain bundle")
         .arg(
-            Arg::new("KEY")
+            Arg::new("BUNDLE-KEY")
                 .required(true)
                 .takes_value(true)
-                .help("Bundle's key"),
+                .help("The key for the bundle which must be shown")
+                .long_help(
+                    "The key for the bundle which must be shown. It can be partially entered.",
+                ),
         );
 
     let download_subcommand = Command::new("download")
         .about("Download all items in a bundle")
         .arg(
-            Arg::new("KEY")
+            Arg::new("BUNDLE-KEY")
                 .required(true)
-                .help("The bundle which must be downloaded"),
+                .help("The key for the bundle which must be downloaded")
+                .long_help(
+                    "The key for the bundle which must be downloaded. It can be partially entered."
+                )
         )
         .arg(
             Arg::new("format")
@@ -199,7 +205,7 @@ fn find_key(all_keys: Vec<String>, key_to_find: &str) -> Option<String> {
 
 fn show_bundle_details(matches: &clap::ArgMatches) -> Result<(), anyhow::Error> {
     let config = get_config()?;
-    let bundle_key = matches.value_of("KEY").unwrap();
+    let bundle_key = matches.value_of("BUNDLE-KEY").unwrap();
     let api = crate::HumbleApi::new(&config.session_key);
 
     let bundle_key = match find_key(api.list_bundle_keys()?, bundle_key) {
@@ -239,7 +245,7 @@ fn show_bundle_details(matches: &clap::ArgMatches) -> Result<(), anyhow::Error> 
 
 fn download_bundle(matches: &clap::ArgMatches) -> Result<(), anyhow::Error> {
     let config = get_config()?;
-    let bundle_key = matches.value_of("KEY").unwrap();
+    let bundle_key = matches.value_of("BUNDLE-KEY").unwrap();
     let formats = if let Some(values) = matches.values_of("format") {
         values.map(|f| f.to_lowercase()).collect::<Vec<_>>()
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ fn list_bundles() -> Result<(), anyhow::Error> {
     let api = HumbleApi::new(&config.session_key);
     let bundles = handle_http_errors(api.list_bundles())?;
 
-    println!("{} bundles(s) found.", bundles.len());
+    println!("{} bundle(s) found.", bundles.len());
 
     let mut builder = tabled::builder::Builder::default().set_columns(["Key", "Name", "Size"]);
     for p in bundles {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,7 +208,7 @@ fn show_bundle_details(matches: &clap::ArgMatches) -> Result<(), anyhow::Error> 
     let bundle_key = matches.value_of("BUNDLE-KEY").unwrap();
     let api = crate::HumbleApi::new(&config.session_key);
 
-    let bundle_key = match find_key(api.list_bundle_keys()?, bundle_key) {
+    let bundle_key = match find_key(handle_http_errors(api.list_bundle_keys())?, bundle_key) {
         Some(key) => key,
         None => return Ok(()),
     };
@@ -261,7 +261,7 @@ fn download_bundle(matches: &clap::ArgMatches) -> Result<(), anyhow::Error> {
 
     let api = crate::HumbleApi::new(&config.session_key);
 
-    let bundle_key = match find_key(api.list_bundle_keys()?, bundle_key) {
+    let bundle_key = match find_key(handle_http_errors(api.list_bundle_keys())?, bundle_key) {
         Some(key) => key,
         None => return Ok(()),
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,6 @@ pub fn run() -> Result<(), anyhow::Error> {
         .about("The missing Humble Bundle CLI")
         .version(clap::crate_version!())
         .after_help("Note: `humble-cli -h` prints a short and concise overview while `humble-cli --help` gives all details.")
-        .propagate_version(true)
         .subcommand_required(true)
         .arg_required_else_help(true)
         .subcommands(sub_commands)


### PR DESCRIPTION
This will allow users to enter keys partially. 

For example, if user wants to see details of a bundle with key `1234567890abcdef`, they can simply enter `humble-cli details 123`.

In case more than bundle matches that [partially] entered key, an error will be shown.