### PR TITLE
Fix 404 error when an exact bundle key is given

### DIFF
--- a/src/key_match.rs
+++ b/src/key_match.rs
@@ -10,7 +10,7 @@ impl KeyMatch {
     pub fn new(keys: Vec<String>, target: &str) -> Self {
         Self {
             keys,
-            target: target.to_lowercase(),
+            target: target.to_owned(),
         }
     }
 
@@ -28,12 +28,22 @@ impl KeyMatch {
             return vec![self.target.clone()];
         }
 
+        let lowercase_target = self.target.to_lowercase();
         self.keys
             .iter()
-            .filter(|k| k.to_lowercase().starts_with(&self.target))
+            .filter(|k| k.to_lowercase().starts_with(&lowercase_target))
             .cloned()
             .collect()
     }
+}
+
+#[test]
+fn test_exact_match() {
+    let keys = vec!["1AaAaA".to_owned(), "2BbBbB".to_owned()];
+    let target = "1AaAaA".to_owned();
+
+    let key_match = KeyMatch::new(keys, &target);
+    assert_eq!(key_match.get_matches(), vec!["1AaAaA".to_owned()]);
 }
 
 #[test]


### PR DESCRIPTION
`KeyMatch` always turned the `target` to lowercase, so an exact match would return a lowercase version of what was entered by the user. This resulted in `404` errors from the API for `details` and `download` commands.