### PR TITLE
Allow downloading only selected items from a bundle

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,7 +221,7 @@ fn show_bundle_details(matches: &clap::ArgMatches) -> Result<(), anyhow::Error> 
     println!();
 
     let mut builder = tabled::builder::Builder::default();
-    builder = builder.set_columns(["", "Sub-item", "Format", "Total Size"]);
+    builder = builder.set_columns(["#", "Sub-item", "Format", "Total Size"]);
 
     for (idx, entry) in bundle.products.iter().enumerate() {
         builder = builder.add_record([

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,7 @@ fn show_bundle_details(matches: &clap::ArgMatches) -> Result<(), anyhow::Error> 
 
     for (idx, entry) in bundle.products.iter().enumerate() {
         builder = builder.add_record([
-            &idx.to_string(),
+            &(idx + 1).to_string(),
             &entry.human_name,
             &entry.formats(),
             &util::humanize_bytes(entry.total_size()),

--- a/src/util.rs
+++ b/src/util.rs
@@ -97,8 +97,23 @@ pub fn parse_usize_range(value: &str, max_value: usize) -> Option<Vec<usize>> {
     let left = &value[0..dash_idx];
     let right = &value[dash_idx + 1..];
 
-    let range_left = left.parse::<usize>().unwrap_or(1);
-    let range_right = right.parse::<usize>().unwrap_or(max_value);
+    let range_left = if left.len() > 0 {
+        match left.parse::<usize>() {
+            Ok(v) => v,
+            Err(_) => return None,
+        }
+    } else {
+        1
+    };
+
+    let range_right = if right.len() > 0 {
+        match right.parse::<usize>() {
+            Ok(v) => v,
+            Err(_) => return None,
+        }
+    } else {
+        max_value
+    };
 
     // These min and max values are intentional:
     // min value is `1` and max value is `max_value + 1`
@@ -172,6 +187,9 @@ fn test_parse_usize_range() {
             "45-",
             Some(vec![45, 46, 47, 48, 49, 50]),
         ), // 50 is MAX_VAL
+        ("invalid start", "abc-", None),
+        ("invalid end", "-abc", None),
+        ("invalid start and end", "abc-def", None),
     ];
 
     for (name, input, expected) in test_data {

--- a/src/util.rs
+++ b/src/util.rs
@@ -86,7 +86,7 @@ where
 ///
 /// Note: the range starts at `1`, **not** `0`.
 pub fn parse_usize_range(value: &str, max_value: usize) -> Option<Vec<usize>> {
-    let dash_idx = value.find("-");
+    let dash_idx = value.find('-');
 
     if dash_idx == None {
         return value.parse::<usize>().map(|v| vec![v]).ok();
@@ -97,7 +97,7 @@ pub fn parse_usize_range(value: &str, max_value: usize) -> Option<Vec<usize>> {
     let left = &value[0..dash_idx];
     let right = &value[dash_idx + 1..];
 
-    let range_left = if left.len() > 0 {
+    let range_left = if !left.is_empty() {
         match left.parse::<usize>() {
             Ok(v) => v,
             Err(_) => return None,
@@ -106,7 +106,7 @@ pub fn parse_usize_range(value: &str, max_value: usize) -> Option<Vec<usize>> {
         1
     };
 
-    let range_right = if right.len() > 0 {
+    let range_right = if !right.is_empty() {
         match right.parse::<usize>() {
             Ok(v) => v,
             Err(_) => return None,
@@ -131,7 +131,7 @@ pub fn union_usize_ranges(values: &[&str], max_value: usize) -> Result<Vec<usize
         }
     }
 
-    if invalid_values.len() > 0 {
+    if !invalid_values.is_empty() {
         let msg = invalid_values
             .into_iter()
             .map(|v| format!("'{}'", v))

--- a/src/util.rs
+++ b/src/util.rs
@@ -107,7 +107,7 @@ fn test_extract_filename_from_url() {
 }
 
 #[test]
-fn vecor_inter() {
+fn test_vectors_intersect() {
     let test_data = vec![
         (vec!["FOO", "bar"], vec!["foo"], true),
         (vec!["foo", "bar"], vec!["baz"], false),


### PR DESCRIPTION
This pull request adds the `--item-numbers` to the `download` subcommand.

Users can specify which items to download from a bundle.

Some examples:

```
# Download items 1, 3, and 5 in bundle 'abcdef'
humble-cli download abcdef --item-numbers 1,3,5

# Download items 6 through 10 in bundle 'abcdef'
humble-cli download abcdef --item-numbers 6-10
```