### PR TITLE
fix issues in list and download

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,10 @@ indicatif = "0.16.2"
 reqwest = { version = "0.11", features = ["json", "blocking", "rustls-tls", "stream"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_with = "2.0.0"
 tabled = "0.7.0"
 thiserror = "1.0"
 tokio = { version = "1.18", features = ["rt-multi-thread", "macros"] }
-
-[dependencies.serde_with]
-version = "2.0.0"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,8 @@ tabled = "0.7.0"
 thiserror = "1.0"
 tokio = { version = "1.18", features = ["rt-multi-thread", "macros"] }
 
+[dependencies.serde_with]
+version = "2.0.0"
+
 [dev-dependencies]
 assert_cmd = "2"

--- a/src/humble_api.rs
+++ b/src/humble_api.rs
@@ -2,6 +2,7 @@ use reqwest::blocking::Client;
 use serde::Deserialize;
 use std::collections::HashMap;
 use thiserror::Error;
+use serde_with::{serde_as, VecSkipError};
 
 #[derive(Debug, Error)]
 pub enum ApiError {
@@ -14,6 +15,7 @@ pub enum ApiError {
 
 type BundleMap = HashMap<String, Bundle>;
 
+#[serde_as]
 #[derive(Debug, Deserialize)]
 pub struct Bundle {
     pub gamekey: String,
@@ -22,6 +24,7 @@ pub struct Bundle {
     pub details: BundleDetails,
 
     #[serde(rename = "subproducts")]
+    #[serde_as(as = "VecSkipError<_>")]
     pub products: Vec<Product>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -329,7 +329,8 @@ fn download_bundle(matches: &clap::ArgMatches) -> Result<(), anyhow::Error> {
         println!();
         println!("{}", product.human_name);
 
-        let entry_dir = bundle_dir.join(&product.human_name);
+        let dir_name = util::replace_invalid_chars_in_filename(&product.human_name);
+        let entry_dir = bundle_dir.join(dir_name);
         if !entry_dir.exists() {
             fs::create_dir(&entry_dir)?;
         }

--- a/tests/models.rs
+++ b/tests/models.rs
@@ -51,5 +51,5 @@ fn product_total_size() {
 
 #[test]
 fn filter_by_total_size() {
-    let product = get_test_product();
+    let _product = get_test_product();
 }


### PR DESCRIPTION
Skip deserializing products vec on error, this can happen if there are none book bundles that has empty subproducts.
Replace invalid product name characters when downloading.