### PR TITLE
Add purchase date information to details command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,9 +111,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
  "serde",
+ "time 0.1.44",
+ "wasm-bindgen",
  "winapi",
 ]
 
@@ -347,7 +350,7 @@ checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -437,6 +440,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "byte-unit",
+ "chrono",
  "clap",
  "dirs",
  "futures-util",
@@ -628,7 +632,7 @@ checksum = "713d550d9b44d89174e066b7a6217ae06234c10cb47819a88290d2b353c31799"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
 ]
 
@@ -1001,7 +1005,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros",
- "time",
+ "time 0.3.14",
 ]
 
 [[package]]
@@ -1140,6 +1144,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
 ]
 
 [[package]]
@@ -1358,6 +1373,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ name = "humble-cli"
 [dependencies]
 anyhow = "1.0"
 byte-unit = { version = "4.0.14", default-features = false }
+chrono = { version = "0.4.22", features = ["serde"] }
 clap = { version = "3.1", features = ["cargo", "derive"] }
 dirs = "4.0.0"
 futures-util = "0.3.21"

--- a/src/humble_api.rs
+++ b/src/humble_api.rs
@@ -4,6 +4,7 @@ use serde::Deserialize;
 use serde_with::{serde_as, VecSkipError};
 use std::collections::HashMap;
 use thiserror::Error;
+use chrono::NaiveDateTime;
 
 #[derive(Debug, Error)]
 pub enum ApiError {
@@ -20,6 +21,7 @@ type BundleMap = HashMap<String, Bundle>;
 #[derive(Debug, Deserialize)]
 pub struct Bundle {
     pub gamekey: String,
+    pub created: NaiveDateTime,
 
     #[serde(rename = "product")]
     pub details: BundleDetails,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,6 +234,7 @@ fn show_bundle_details(matches: &clap::ArgMatches) -> Result<(), anyhow::Error> 
 
     println!();
     println!("{}", bundle.details.human_name);
+    println!("Purchased: {}", bundle.created.format("%v %I:%M %p"));
     println!("Total size: {}", util::humanize_bytes(bundle.total_size()));
     println!();
 


### PR DESCRIPTION
Shows when a bundle was purchased when using the `details` command, like so:

```
humble-cli.exe details <BUNDLE-KEY>

Skybound's The Walking Dead Bundle presented by Humble Bundle
Purchased:  1-Aug-2014 09:29 PM
Total size: 638.10 MiB

 # | Sub-item                  | Format                    | Total Size
---+---------------------------+---------------------------+------------
 1 | The Walking Dead, Issue 3 | .cbz, EPUB, PDF, PDF (HD) | 179.08 MiB
 2 | The Walking Dead, Issue 1 | .cbz, EPUB, PDF, PDF (HD) | 248.73 MiB
 3 | The Walking Dead, Issue 2 | .cbz, EPUB, PDF, PDF (HD) | 210.29 MiB
```

I'm not entirely sure what timezone the `created` info from the API is using, or if it's stored in local time. It doesn't include timezone information, which is why I used `NaiveDateTime` to parse it.