### PR TITLE
Filter bundles list by "claimed" field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,7 +504,7 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "humble-cli"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "humble-cli"
 authors = ["Mohammad Banisaeid <smbl64@gmail.com>"]
-version = "0.7.1"
+version = "0.8.0"
 license = "MIT"
 description = "The missing CLI for downloading your Humble Bundle purchases"
 documentation = "https://github.com/smbl64/humble-cli"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ After that you will have access to the following sub-commands:
 ```
 $ humble-cli --help
 
-humble-cli 0.7.1
+humble-cli 0.8.0
 The missing Humble Bundle CLI
 
 USAGE:

--- a/src/humble_api.rs
+++ b/src/humble_api.rs
@@ -1,10 +1,10 @@
+use chrono::NaiveDateTime;
 use futures_util::future;
 use reqwest::blocking::Client;
 use serde::Deserialize;
 use serde_with::{serde_as, VecSkipError};
 use std::collections::HashMap;
 use thiserror::Error;
-use chrono::NaiveDateTime;
 
 #[derive(Debug, Error)]
 pub enum ApiError {
@@ -22,6 +22,7 @@ type BundleMap = HashMap<String, Bundle>;
 pub struct Bundle {
     pub gamekey: String,
     pub created: NaiveDateTime,
+    pub claimed: bool,
 
     #[serde(rename = "product")]
     pub details: BundleDetails,


### PR DESCRIPTION
This PR adds a new `--claimed` filter to the `list` subcommand. Using this, user can see a list of unclaimed games.

Closes #17 