### PR TITLE
Sort bundles list by creation date

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,7 +630,7 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "humble-cli"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "humble-cli"
 authors = ["Mohammad Banisaeid <smbl64@gmail.com>"]
-version = "0.9.1"
+version = "0.10.0"
 license = "MIT"
 description = "The missing CLI for downloading your Humble Bundle purchases"
 documentation = "https://github.com/smbl64/humble-cli"

--- a/src/humble_api.rs
+++ b/src/humble_api.rs
@@ -72,7 +72,9 @@ impl HumbleApi {
             .into_iter()
             .collect();
 
-        Ok(result?.into_iter().flatten().collect())
+        let mut bundles: Vec<_> = result?.into_iter().flatten().collect();
+        bundles.sort_by(|a, b| a.created.partial_cmp(&b.created).unwrap());
+        Ok(bundles)
     }
 
     async fn read_bundles_data(
@@ -80,10 +82,7 @@ impl HumbleApi {
         client: &reqwest::Client,
         keys: &[String],
     ) -> Result<Vec<Bundle>, ApiError> {
-        let mut query_params: Vec<_> = keys
-            .iter()
-            .map(|key| ("gamekeys", key.as_str()))
-            .collect();
+        let mut query_params: Vec<_> = keys.iter().map(|key| ("gamekeys", key.as_str())).collect();
 
         query_params.insert(0, ("all_tpkds", "true"));
 


### PR DESCRIPTION
Use bundles' `created` field to sort them in `humble-cli list` command. This will generate a consistent output whenever the command is run.