### PR TITLE
Add the `search` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,7 +636,7 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "humble-cli"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytecount"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -931,10 +937,12 @@ checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "papergrid"
-version = "0.4.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608b6444acf7f5ea39e8bd06dd6037e34a4b5ddfb29ae840edad49ea798e9e79"
+checksum = "a2ccbe15f2b6db62f9a9871642746427e297b0ceb85f9a7f1ee5ff47d184d0c8"
 dependencies = [
+ "bytecount",
+ "fnv",
  "unicode-width",
 ]
 
@@ -1612,20 +1620,23 @@ dependencies = [
 
 [[package]]
 name = "tabled"
-version = "0.7.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2407502760ccfd538f2fb1f843dd87b6daf1a17848d57bc5a25617e408ef4c7a"
+checksum = "dfe9c3632da101aba5131ed63f9eed38665f8b3c68703a6bb18124835c1a5d22"
 dependencies = [
  "papergrid",
  "tabled_derive",
+ "unicode-width",
 ]
 
 [[package]]
 name = "tabled_derive"
-version = "0.3.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "278ea3921cee8c5a69e0542998a089f7a14fa43c9c4e4f9951295da89bd0c943"
+checksum = "99f688a08b54f4f02f0a3c382aefdb7884d3d69609f785bd253dc033243e3fe4"
 dependencies = [
+ "heck",
+ "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ scraper = "0.15.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = "2.0"
-tabled = "0.7"
+tabled = "0.14"
 thiserror = "1.0"
 tokio = { version = "1.18", features = ["full"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "humble-cli"
 authors = ["Mohammad Banisaeid <smbl64@gmail.com>"]
-version = "0.11.0"
+version = "0.12.0"
 license = "MIT"
 description = "The missing CLI for downloading your Humble Bundle purchases"
 documentation = "https://github.com/smbl64/humble-cli"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The missing CLI for downloading your Humble Bundle purchases!
     - download only selected items (by index)
 - See which bundles have unclaimed keys
 - Check your Humble Bundle Choices in current and previous months
+- Search through all your purchases for a specific product
 
 ## Install
 Option 1: Download the binaries in the [Releases][releases] page. Windows, macOS and Linux are supported.
@@ -35,7 +36,7 @@ After that you will have access to the following sub-commands:
 ```
 $ humble-cli --help
 
-humble-cli 0.11.0
+humble-cli 0.12.0
 The missing Humble Bundle CLI
 
 USAGE:
@@ -52,6 +53,7 @@ SUBCOMMANDS:
     help            Print this message or the help of the given subcommand(s)
     list            List all your purchased bundles
     list-choices    List your current Humble Choices
+    search          Search through all bundle products for keywords
 
 Note: `humble-cli -h` prints a short and concise overview while `humble-cli --help` gives all
 details.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,11 +102,12 @@ pub fn list_humble_choices(period: &ChoicePeriod) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-pub fn search(keywords: &str) -> Result<(), anyhow::Error> {
+pub fn search(keywords: &str, match_mode: MatchMode) -> Result<(), anyhow::Error> {
     let config = get_config()?;
     let api = HumbleApi::new(&config.session_key);
 
-    let keyword = keywords.to_lowercase();
+    let keywords = keywords.to_lowercase();
+    let keywords: Vec<&str> = keywords.split(" ").collect();
 
     let bundles = handle_http_errors(api.list_bundles())?;
     type BundleItem<'a> = (&'a Bundle, String);
@@ -114,7 +115,7 @@ pub fn search(keywords: &str) -> Result<(), anyhow::Error> {
 
     for b in &bundles {
         for p in &b.products {
-            if p.human_name.to_lowercase().contains(&keyword) {
+            if p.name_matches(&keywords, &match_mode) {
                 search_result.push((b, p.human_name.to_owned()));
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,6 +73,15 @@ fn run() -> Result<(), anyhow::Error> {
                 ),
         );
 
+    let search_subcommand = Command::new("search")
+        .about("Search through all bundles for some keywords")
+        .arg(
+            Arg::new("KEYWORDS")
+                .required(true)
+                .takes_value(true)
+                .help("Search keywords"),
+        );
+
     let download_subcommand = Command::new("download")
         .about("Selectively download items from a bundle")
         .arg(
@@ -136,6 +145,7 @@ fn run() -> Result<(), anyhow::Error> {
         list_choices_subcommand,
         details_subcommand,
         download_subcommand,
+        search_subcommand,
     ];
 
     let crate_name = clap::crate_name!();
@@ -157,6 +167,10 @@ fn run() -> Result<(), anyhow::Error> {
         Some(("details", sub_matches)) => {
             let bundle_key = sub_matches.value_of("BUNDLE-KEY").unwrap();
             show_bundle_details(bundle_key)
+        }
+        Some(("search", sub_matches)) => {
+            let ketwords = sub_matches.value_of("KEYWORDS").unwrap();
+            search(ketwords)
         }
         Some(("download", sub_matches)) => {
             let bundle_key = sub_matches.value_of("BUNDLE-KEY").unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,7 @@ fn run() -> Result<(), anyhow::Error> {
         );
 
     let search_subcommand = Command::new("search")
-        .about("Search through all bundles for some keywords")
+        .about("Search through all bundle products for keywords")
         .arg(
             Arg::new("KEYWORDS")
                 .required(true)

--- a/tests/models.rs
+++ b/tests/models.rs
@@ -94,3 +94,54 @@ fn choice_period_parses() {
         );
     }
 }
+
+#[test]
+fn product_name_matches() {
+    struct TestData {
+        name: String,
+        keywords: String,
+        match_mode: MatchMode,
+        expected: bool,
+    }
+
+    let test_data = vec![
+        TestData {
+            name: "Python programming".to_owned(),
+            keywords: "python".to_owned(),
+            match_mode: MatchMode::Any,
+            expected: true,
+        },
+        TestData {
+            name: "Python programming".to_owned(),
+            keywords: "java".to_owned(),
+            match_mode: MatchMode::Any,
+            expected: false,
+        },
+        TestData {
+            name: "Programming in Rust second edition".to_owned(),
+            keywords: "rust edition".to_owned(),
+            match_mode: MatchMode::All,
+            expected: true,
+        },
+        TestData {
+            name: "Programming in Rust second edition".to_owned(),
+            keywords: "rust third".to_owned(),
+            match_mode: MatchMode::All,
+            expected: false,
+        },
+    ];
+
+    for td in test_data {
+        let mut product = Product::default();
+        product.human_name = td.name.clone();
+
+        let keywords = td.keywords.to_lowercase();
+        let keywords: Vec<&str> = keywords.split(" ").collect();
+        let got = product.name_matches(&keywords, &td.match_mode);
+        assert_eq!(
+            got, td.expected,
+            "expected {}, got {}, name = {}, keywords = {}, mode = {:?}",
+            td.expected, got, td.name, td.keywords, &td.match_mode,
+        )
+    }
+}


### PR DESCRIPTION
Using the `search` subcommand, user can find products (e.g. books) within all bundles.