### PR TITLE
Add subcommand aliases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,7 +636,7 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "humble-cli"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "humble-cli"
 authors = ["Mohammad Banisaeid <smbl64@gmail.com>"]
-version = "0.12.0"
+version = "0.13.0"
 license = "MIT"
 description = "The missing CLI for downloading your Humble Bundle purchases"
 documentation = "https://github.com/smbl64/humble-cli"

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ The missing CLI for downloading your Humble Bundle purchases!
 - Search through all your purchases for a specific product
 
 ## Install
-Option 1: Download the binaries in the [Releases][releases] page. Windows, macOS and Linux are supported.
+**Option 1:** Download the binaries in the [Releases][releases] page. Windows, macOS and Linux are supported.
 
-Option 2: Install it via `cargo`:
+**Option 2:** Install it via `cargo`:
 
 ```sh
 cargo install humble-cli
@@ -34,9 +34,7 @@ Use `humble-cli auth "<YOUR SESSION KEY>"` to store the authentication key local
 After that you will have access to the following sub-commands:
 
 ```
-$ humble-cli --help
-
-humble-cli 0.12.0
+$ humble-cli 0.13.0
 The missing Humble Bundle CLI
 
 USAGE:
@@ -48,10 +46,10 @@ OPTIONS:
 
 SUBCOMMANDS:
     auth            Set the authentication session key
-    details         Print details of a certain bundle
-    download        Selectively download items from a bundle
+    details         Print details of a certain bundle [aliases: info]
+    download        Selectively download items from a bundle [aliases: d]
     help            Print this message or the help of the given subcommand(s)
-    list            List all your purchased bundles
+    list            List all your purchased bundles [aliases: ls]
     list-choices    List your current Humble Choices
     search          Search through all bundle products for keywords
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ fn parse_match_mode(input: &str) -> Result<MatchMode, anyhow::Error> {
 fn run() -> Result<(), anyhow::Error> {
     let list_subcommand = Command::new("list")
         .about("List all your purchased bundles")
+        .visible_alias("ls")
         .arg(
         Arg::new("id-only")
             .long("id-only")
@@ -67,6 +68,7 @@ fn run() -> Result<(), anyhow::Error> {
 
     let details_subcommand = Command::new("details")
         .about("Print details of a certain bundle")
+        .visible_alias("info")
         .arg(
             Arg::new("BUNDLE-KEY")
                 .required(true)
@@ -99,6 +101,7 @@ fn run() -> Result<(), anyhow::Error> {
 
     let download_subcommand = Command::new("download")
         .about("Selectively download items from a bundle")
+        .visible_alias("d")
         .arg(
             Arg::new("BUNDLE-KEY")
                 .required(true)


### PR DESCRIPTION
Add the following aliases for subcommands:

- `info` for `details`
- `d` for `download`
- `ls` for `list`