### PR TITLE
Add `completion` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,6 +216,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "3.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f7a2e0a962c45ce25afce14220bc24f9dade0a1787f185cecf96bfba7847cd8"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,6 +692,7 @@ dependencies = [
  "byte-unit",
  "chrono",
  "clap",
+ "clap_complete",
  "dirs",
  "futures-util",
  "indicatif",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,7 +685,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humble-cli"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "humble-cli"
 authors = ["Mohammad Banisaeid <smbl64@gmail.com>"]
-version = "0.13.1"
+version = "0.14.0"
 license = "MIT"
 description = "The missing CLI for downloading your Humble Bundle purchases"
 documentation = "https://github.com/smbl64/humble-cli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ anyhow = "1.0"
 byte-unit = { version = "4.0", default-features = false }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "3.1", features = ["cargo", "derive"] }
+clap_complete = "3.2"
 dirs = "4.0.0"
 futures-util = "0.3"
 indicatif = "0.16"

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Use `humble-cli auth "<YOUR SESSION KEY>"` to store the authentication key local
 After that you will have access to the following sub-commands:
 
 ```
-$ humble-cli 0.13.1
+$ humble-cli --help
+humble-cli 0.14.0
 The missing Humble Bundle CLI
 
 USAGE:
@@ -48,6 +49,7 @@ OPTIONS:
 
 SUBCOMMANDS:
     auth            Set the authentication session key
+    completion      Generate shell completions
     details         Print details of a certain bundle [aliases: info]
     download        Selectively download items from a bundle [aliases: d]
     help            Print this message or the help of the given subcommand(s)


### PR DESCRIPTION
This PR adds `completion` command to generate shell completion for Bash, zsh, and other shell types.