### PR TITLE
Add Timeouts to (large) downloads, should fix smbl64/humble-cli#55

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,11 +25,13 @@ use key_match::KeyMatch;
 use prelude::*;
 use std::fs;
 use std::path;
+use std::time::Duration;
 use tabled::settings::object::Columns;
 use tabled::settings::Alignment;
 use tabled::settings::Merge;
 use tabled::settings::Modify;
 use tabled::settings::Style;
+
 
 pub fn auth(session_key: &str) -> Result<(), anyhow::Error> {
     set_config(Config {
@@ -367,7 +369,10 @@ pub fn download_bundle(
     let dir_name = util::replace_invalid_chars_in_filename(&bundle.details.human_name);
     let bundle_dir = create_dir(&dir_name)?;
 
-    let client = reqwest::Client::new();
+    let http_read_timeout = Duration::from_secs(30);
+    let client = reqwest::Client::builder()
+        .read_timeout(http_read_timeout)
+        .build()?;
 
     for product in products {
         if max_size > 0 && product.total_size() > max_size {


### PR DESCRIPTION
Since I just had to take a stab at it...

These two commits will fix the problem of #55...at least for me. I must admit though, that the first commit on its own might be sufficient...(I used the installed version to test, and since it did not fix the issue, I added the second timeout...only after that I figured out what was wrong and tested the correct binary..)

The timeouts are hardcoded, and maybe (at least the chunk one) too low for slow internet connections..

Anyways, hope these at least help to build a correct solution to the problem ;-)

(Take note, this is the first time I actually touched rust code, so...it might be a complete boneheadded way to go about fixing the issue...I did run the `cargo test` command and it seems that I have not broken anything under coverage at least ;-) 

