### PR TITLE
Added --torrents flag to download command to only fetch Bittorrent files

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,6 +323,7 @@ pub fn download_bundle(
     formats: Vec<String>,
     max_size: u64,
     item_numbers: Option<&str>,
+    torrents_only: bool,
 ) -> Result<(), anyhow::Error> {
     let config = get_config()?;
 
@@ -395,14 +396,20 @@ pub fn download_bundle(
                     continue;
                 }
 
-                let filename = util::extract_filename_from_url(&dl_info.url.web).context(
-                    format!("Cannot get file name from URL '{}'", &dl_info.url.web),
+                let download_url = if torrents_only {
+                    &dl_info.url.bittorrent
+                } else {
+                    &dl_info.url.web
+                };
+
+                let filename = util::extract_filename_from_url(&download_url).context(
+                    format!("Cannot get file name from URL '{}'", &download_url),
                 )?;
                 let download_path = entry_dir.join(&filename);
 
                 let f = download::download_file(
                     &client,
-                    &dl_info.url.web,
+                    &download_url,
                     download_path.to_str().unwrap(),
                     &filename,
                 );

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,6 +155,18 @@ fn run() -> Result<(), anyhow::Error> {
                 )
         )
         .arg(
+            Arg::new("torrents")
+                .short('t')
+                .long("torrents")
+                .takes_value(false)
+                .help("Download only .torrent files for items")
+                .long_help(
+                    "Download only the BitTorrent files for the given items. This will prevent \
+                    all the original files from downloading. To download both, run again without \
+                    this flag."
+                )
+        )
+        .arg(
             Arg::new("max-size")
                 .short('s')
                 .long("max-size")
@@ -231,7 +243,8 @@ fn run() -> Result<(), anyhow::Error> {
                 0
             };
             let item_numbers = sub_matches.value_of("item-numbers");
-            download_bundle(bundle_key, formats, max_size, item_numbers)
+            let torrents_only = sub_matches.is_present("torrents");
+            download_bundle(bundle_key, formats, max_size, item_numbers, torrents_only)
         }
         Some(("list", sub_matches)) => {
             let id_only = sub_matches.is_present("id-only");

--- a/tests/models.rs
+++ b/tests/models.rs
@@ -3,7 +3,7 @@ use humble_cli::prelude::*;
 fn new_download_url(web_url: &str) -> DownloadUrl {
     DownloadUrl {
         web: web_url.to_string(),
-        bittorrent: "".to_string(),
+        bittorrent: web_url.to_string() + ".torrent",
     }
 }
 


### PR DESCRIPTION
Added the ability to download the torrent files, rather than the full-sized files over http.

This is useful for very large files or to add the downloads to a machine that may not have humble-cli installed.