### PR TITLE
Show the amount spent in the `details` command

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,8 +246,12 @@ pub fn show_bundle_details(bundle_key: &str) -> Result<(), anyhow::Error> {
     println!();
     println!("{}", bundle.details.human_name);
     println!();
-    println!("Purchased  : {}", bundle.created.format("%v %I:%M %p"));
-    println!("Total size : {}", util::humanize_bytes(bundle.total_size()));
+    println!("Purchased    : {}", bundle.created.format("%Y-%m-%d"));
+    println!("Amount spent : {} {}", bundle.amount_spent, bundle.currency);
+    println!(
+        "Total size   : {}",
+        util::humanize_bytes(bundle.total_size())
+    );
     println!();
 
     if !bundle.products.is_empty() {

--- a/src/models.rs
+++ b/src/models.rs
@@ -42,6 +42,9 @@ pub struct Bundle {
     #[serde(rename = "subproducts")]
     #[serde_as(as = "VecSkipError<_>")]
     pub products: Vec<Product>,
+
+    pub amount_spent: f64,
+    pub currency: String,
 }
 
 pub struct ProductKey {


### PR DESCRIPTION
With this, `details` subcommand will show the amount spent to purchase a bundle.

Example output:
```
$ humble-cli details f2PbfA

Humble Tech Book Bundle: Elixir and Phoenix Programming 2024 by Pragmatic

Purchased    : 2024-06-11
Amount spent : 16.56 EUR
Total size   : 315.15 MiB

[...]

```

Resolves #128 