### PR TITLE
Upgrade ubuntu runner to 24.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, macos-latest]
+        os: [ubuntu-24.04, ubuntu-22.04, macos-latest]
         rust: [stable, beta]
 
     steps:


### PR DESCRIPTION
Ubuntu 20.04 is being deprecated in Actions: https://github.com/actions/runner-images/issues/11101