### PR TITLE
Bulk download and export format changes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,13 +176,7 @@ pub fn list_bundles(fields: Vec<String>, claimed_filter: &str) -> Result<(), any
         });
     }
 
-    if key_only {
-        for b in bundles {
-            println!("{}", b.gamekey);
-        }
-
-        return Ok(());
-    } else if !fields.is_empty() {
+    if !fields.is_empty() {
         return bulk_format(&fields, &bundles);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -487,8 +487,5 @@ fn create_dir(dir: &str) -> Result<path::PathBuf, std::io::Error> {
 
 fn open_dir(dir: &str) -> Result<path::PathBuf, std::io::Error> {
     let dir = path::Path::new(dir).to_owned();
-    if !dir.exists() {
-        fs::create_dir(&dir)?;
-    }
     Ok(dir)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -483,46 +483,27 @@ fn validate_fields(fields: &[String]) -> bool {
 
 fn bulk_format(fields: &[String], bundles: &[Bundle]) -> Result<(), anyhow::Error> {
     if !validate_fields(fields) {
-        return Err(anyhow!("invalid field in fields: {:?}", fields));
+        return Err(anyhow!("invalid field in fields: {}", fields.join(",")));
     }
     let print_key = fields.contains(&VALID_FIELDS[0].to_lowercase());
     let print_name = fields.contains(&VALID_FIELDS[1].to_lowercase());
     let print_size = fields.contains(&VALID_FIELDS[2].to_lowercase());
     let print_claimed = fields.contains(&VALID_FIELDS[3].to_lowercase());
     for b in bundles {
-        let print_string = if print_key {
-            b.gamekey.clone()
-        } else {
-            String::new()
+        let mut print_vec: Vec<String> = Vec::new();
+        if print_key {
+            print_vec.push(b.gamekey.clone());
         };
-        let print_string = if print_name {
-            format!(
-                "{},{}",
-                print_string.as_str(),
-                b.details.human_name.as_str()
-            )
-        } else {
-            print_string
+        if print_name {
+            print_vec.push(b.details.human_name.clone());
         };
-        let print_string = if print_size {
-            format!(
-                "{},{}",
-                print_string.as_str(),
-                util::humanize_bytes(b.total_size()).as_str()
-            )
-        } else {
-            print_string
+        if print_size {
+            print_vec.push(util::humanize_bytes(b.total_size()))
         };
-        let print_string = if print_claimed {
-            format!(
-                "{},{}",
-                print_string.as_str(),
-                b.claim_status().to_string().as_str()
-            )
-        } else {
-            print_string
+        if print_claimed {
+            print_vec.push(b.claim_status().to_string())
         };
-        println!("{}", print_string);
+        println!("{}", print_vec.join(","));
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,11 +26,15 @@ fn run() -> Result<(), anyhow::Error> {
         .about("List all your purchased bundles")
         .visible_alias("ls")
         .arg(
-        Arg::new("id-only")
-            .long("id-only")
-            .help("Print bundle IDs only")
+        Arg::new("fields")
+            .long("fields")
+            .takes_value(true)
+            .multiple_occurrences(true)
+            .help("Print bundle with the specified fields only")
             .long_help(
-                "Print bundle IDs only. This can be used to chain commands together for automation.",
+                "Print bundle with the specified fields only. This can be used to chain commands together for automation. \
+                 If fields are not set, all fields will be printed  \
+                 Use example: --fields id --fields name ",
             ),
     ).arg(
         Arg::new("claimed")
@@ -45,13 +49,6 @@ fn run() -> Result<(), anyhow::Error> {
                 "Show claimed or unclaimed bundles only. \
                     This is useful if you want to know which games or bundles you have not claimed yet."
             )
-    ).arg(
-        Arg::new("bulk-format")
-            .long("bulk-format")
-            .help("Print bundle in bulk-format")
-            .long_help(
-                "Print bundle in bulkd-download format. This can be used to chain commands together for automation.",
-            ),
     );
 
     let completion_subcommand = Command::new("completion")
@@ -335,13 +332,16 @@ fn run() -> Result<(), anyhow::Error> {
             )
         }
         Some(("list", sub_matches)) => {
-            let id_only = sub_matches.is_present("id-only");
-            let bulk_format = sub_matches.is_present("bulk-format");
+            let fields = if let Some(values) = sub_matches.values_of("fields") {
+                values.map(|f| f.to_lowercase()).collect::<Vec<_>>()
+            } else {
+                vec![]
+            };
             let claimed_filter = sub_matches
                 .get_one::<String>("claimed")
                 .map(String::as_str)
                 .unwrap_or("all");
-            list_bundles(id_only, claimed_filter, bulk_format)
+            list_bundles(fields, claimed_filter)
         }
         Some(("list-choices", sub_matches)) => {
             let period: &ChoicePeriod = sub_matches.get_one("period").unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ fn run() -> Result<(), anyhow::Error> {
         .arg(
             Arg::new("SHELL")
                 .help("Shell type to generate completions for")
-                .possible_values(&["bash", "elvish", "fish", "powershell", "zsh"])
+                .possible_values(["bash", "elvish", "fish", "powershell", "zsh"])
                 .takes_value(true)
                 .required(true)
                 .value_parser(value_parser!(Shell)),
@@ -304,7 +304,7 @@ fn run() -> Result<(), anyhow::Error> {
             };
             let item_numbers = sub_matches.value_of("item-numbers");
             let torrents_only = sub_matches.is_present("torrents");
-            download_bundle(bundle_key, formats, max_size, item_numbers, torrents_only)
+            download_bundle(bundle_key, &formats, max_size, item_numbers, torrents_only)
         }
         Some(("list", sub_matches)) => {
             let id_only = sub_matches.is_present("id-only");

--- a/src/main.rs
+++ b/src/main.rs
@@ -333,7 +333,7 @@ fn run() -> Result<(), anyhow::Error> {
             )
         }
         Some(("list", sub_matches)) => {
-            let fields = if let Some(values) = sub_matches.values_of("fields") {
+            let fields = if let Some(values) = sub_matches.values_of("field") {
                 values.map(|f| f.to_lowercase()).collect::<Vec<_>>()
             } else {
                 vec![]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use std::io;
 use anyhow::Context;
 use clap::{builder::ValueParser, value_parser, Arg, Command};
 use clap_complete::Shell;
-use humble_cli::prelude::*;
+use humble_cli::{download_bundles, prelude::*};
 
 fn main() {
     let crate_name = env!("CARGO_PKG_NAME");
@@ -45,6 +45,13 @@ fn run() -> Result<(), anyhow::Error> {
                 "Show claimed or unclaimed bundles only. \
                     This is useful if you want to know which games or bundles you have not claimed yet."
             )
+    ).arg(
+        Arg::new("bulk-format")
+            .long("bulk-format")
+            .help("Print bundle in bulk-format")
+            .long_help(
+                "Print bundle in bulkd-download format. This can be used to chain commands together for automation.",
+            ),
     );
 
     let completion_subcommand = Command::new("completion")
@@ -112,7 +119,6 @@ fn run() -> Result<(), anyhow::Error> {
                 .value_parser(ValueParser::new(parse_match_mode))
                 .help("Whether all or any of the keywords should match the name"),
         );
-
     let download_subcommand = Command::new("download")
         .about("Selectively download items from a bundle")
         .visible_alias("d")
@@ -181,16 +187,59 @@ fn run() -> Result<(), anyhow::Error> {
                     For example, if you specify a limit of 10 MB and a sub-item has two 6 MB books in it, \
                     this sub-items will not be downloaded, because its total size exceeds the 10 MB limit (12 MB in total)."
                     )
-        )
+        );
+
+    let bulk_download_subcommand = Command::new("bulk-download")
+        .about("Selectively download items from a bundle")
+        .visible_alias("b")
         .arg(
-            Arg::new("input-list")
-                .short('l')
-                .long("input-list")
-                .takes_value(true)
+            Arg::new("INPUT-FILE")
+                .required(true)
                 .help("Takes a list input file")
                 .long_help(
                     "This takes the input created from the list command, then iterates all items, \
                     Using the bundle name as directory name")
+        )
+        .arg(
+            Arg::new("format")
+                .short('f')
+                .long("format")
+                .takes_value(true)
+                .multiple_occurrences(true)
+                .help("Filter downloaded items by their format")
+                .long_help(
+                    "Filter downloaded files by their format. Formats are case-insensitive and \
+                    this filter can be used several times to specify multiple formats.\n\n\
+                    For example: --filter-by-format epub --filter-by-format mobi"
+                )
+        )
+        .arg(
+            Arg::new("torrents")
+                .short('t')
+                .long("torrents")
+                .takes_value(false)
+                .help("Download only .torrent files for items")
+                .long_help(
+                    "Download only the BitTorrent files for the given items. This will prevent \
+                    all the original files from downloading. To download both, run again without \
+                    this flag."
+                )
+        )
+        .arg(
+            Arg::new("max-size")
+                .short('s')
+                .long("max-size")
+                .takes_value(true)
+                .help("Filter downloaded items by their maximum size")
+                .long_help(
+                    "Filter downloaded items by their maximum size. This will skip any sub-item in a bundle \
+                    that exceeds this limit. \
+                    You can use the traditional size units such as KB or MiB. Make sure there is no space \
+                    between the number and the unit. For example 14MB or 4GiB.\n\n\
+                    Note: The size limit works on a sub-item level, and not per file. \
+                    For example, if you specify a limit of 10 MB and a sub-item has two 6 MB books in it, \
+                    this sub-items will not be downloaded, because its total size exceeds the 10 MB limit (12 MB in total)."
+                    )
         );
 
     let sub_commands = vec![
@@ -201,6 +250,7 @@ fn run() -> Result<(), anyhow::Error> {
         download_subcommand,
         search_subcommand,
         completion_subcommand,
+        bulk_download_subcommand,
     ];
 
     let crate_name = clap::crate_name!();
@@ -214,7 +264,7 @@ fn run() -> Result<(), anyhow::Error> {
         .subcommands(sub_commands);
 
     let matches = root.clone().get_matches();
-    return match matches.subcommand() {
+    match matches.subcommand() {
         Some(("completion", sub_matches)) => {
             if let Some(g) = sub_matches.get_one::<Shell>("SHELL").copied() {
                 let crate_name = clap::crate_name!();
@@ -258,18 +308,34 @@ fn run() -> Result<(), anyhow::Error> {
         }
         Some(("list", sub_matches)) => {
             let id_only = sub_matches.is_present("id-only");
+            let bulk_format = sub_matches.is_present("bulk-format");
             let claimed_filter = sub_matches
                 .get_one::<String>("claimed")
                 .map(String::as_str)
                 .unwrap_or("all");
-            list_bundles(id_only, claimed_filter)
+            list_bundles(id_only, claimed_filter, bulk_format)
         }
         Some(("list-choices", sub_matches)) => {
             let period: &ChoicePeriod = sub_matches.get_one("period").unwrap();
             list_humble_choices(period)
         }
-
+        Some(("bulk-download", sub_matches)) => {
+            let bundle_file = sub_matches.value_of("INPUT-FILE").unwrap();
+            let formats = if let Some(values) = sub_matches.values_of("format") {
+                values.map(|f| f.to_lowercase()).collect::<Vec<_>>()
+            } else {
+                vec![]
+            };
+            let max_size: u64 = if let Some(byte_str) = sub_matches.value_of("max-size") {
+                byte_string_to_number(byte_str)
+                    .context(format!("failed to parse the specified size: {}", byte_str))?
+            } else {
+                0
+            };
+            let torrents_only = sub_matches.is_present("torrents");
+            download_bundles(bundle_file, formats, max_size, torrents_only)
+        }
         // This shouldn't happen
         _ => Ok(()),
-    };
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,15 +26,16 @@ fn run() -> Result<(), anyhow::Error> {
         .about("List all your purchased bundles")
         .visible_alias("ls")
         .arg(
-        Arg::new("fields")
-            .long("fields")
+        Arg::new("field")
+            .long("field")
             .takes_value(true)
             .multiple_occurrences(true)
             .help("Print bundle with the specified fields only")
             .long_help(
                 "Print bundle with the specified fields only. This can be used to chain commands together for automation. \
                  If fields are not set, all fields will be printed  \
-                 Use example: --fields id --fields name ",
+                 Valid Fields: [key, name, size, claimed] \
+                 Use example: --field key --field name ",
             ),
     ).arg(
         Arg::new("claimed")

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,6 +187,16 @@ fn run() -> Result<(), anyhow::Error> {
                     For example, if you specify a limit of 10 MB and a sub-item has two 6 MB books in it, \
                     this sub-items will not be downloaded, because its total size exceeds the 10 MB limit (12 MB in total)."
                     )
+        ).arg(
+            Arg::new("cur-dir")
+                .short('c')
+                .long("cur-dir")
+                .takes_value(false)
+                .help("Download into current dir")
+                .long_help(
+                    "One Directoy for each entry is created, \
+                    but no bundle directory is created."
+                )
         );
 
     let bulk_download_subcommand = Command::new("bulk-download")
@@ -240,6 +250,16 @@ fn run() -> Result<(), anyhow::Error> {
                     For example, if you specify a limit of 10 MB and a sub-item has two 6 MB books in it, \
                     this sub-items will not be downloaded, because its total size exceeds the 10 MB limit (12 MB in total)."
                     )
+        ).arg(
+            Arg::new("cur-dir")
+                .short('c')
+                .long("cur-dir")
+                .takes_value(false)
+                .help("Download into current dir")
+                .long_help(
+                    "One Directoy for each entry is created, \
+                    but no bundle directory is created."
+                )
         );
 
     let sub_commands = vec![
@@ -304,7 +324,15 @@ fn run() -> Result<(), anyhow::Error> {
             };
             let item_numbers = sub_matches.value_of("item-numbers");
             let torrents_only = sub_matches.is_present("torrents");
-            download_bundle(bundle_key, &formats, max_size, item_numbers, torrents_only)
+            let cur_dir = sub_matches.is_present("cur-dir");
+            download_bundle(
+                bundle_key,
+                &formats,
+                max_size,
+                item_numbers,
+                torrents_only,
+                cur_dir,
+            )
         }
         Some(("list", sub_matches)) => {
             let id_only = sub_matches.is_present("id-only");
@@ -333,7 +361,8 @@ fn run() -> Result<(), anyhow::Error> {
                 0
             };
             let torrents_only = sub_matches.is_present("torrents");
-            download_bundles(bundle_file, formats, max_size, torrents_only)
+            let cur_dir = sub_matches.is_present("cur-dir");
+            download_bundles(bundle_file, formats, max_size, torrents_only, cur_dir)
         }
         // This shouldn't happen
         _ => Ok(()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,6 +181,16 @@ fn run() -> Result<(), anyhow::Error> {
                     For example, if you specify a limit of 10 MB and a sub-item has two 6 MB books in it, \
                     this sub-items will not be downloaded, because its total size exceeds the 10 MB limit (12 MB in total)."
                     )
+        )
+        .arg(
+            Arg::new("input-list")
+                .short('l')
+                .long("input-list")
+                .takes_value(true)
+                .help("Takes a list input file")
+                .long_help(
+                    "This takes the input created from the list command, then iterates all items, \
+                    Using the bundle name as directory name")
         );
 
     let sub_commands = vec![

--- a/src/util.rs
+++ b/src/util.rs
@@ -11,7 +11,7 @@ where
 
 pub fn humanize_bytes(bytes: u64) -> String {
     let b = Byte::from_u64(bytes).get_appropriate_unit(UnitType::Binary);
-    return format!("{b:.2}");
+    format!("{b:.2}")
 }
 
 // Convert a string representing a byte size (e.g. 12MB) to a number.


### PR DESCRIPTION
For my own use-cases I decided to add a change in list export format, and use that format to bulk download.

by using the existing "bundle key only" list export option, you could do the same, but then you would most likely need to export it twice ( one with names, one without) then choose the once you want to download, then create sh/fish/zsh script to iterate the file. 

My changes allows the user to export once into file, then read the file, in a CSV ish way, to sort the contents. (Keeping it somewhat readable)
Then being able to use the content of the file in a single bulk-download command, iterating the file without the need of extra scripts.

Changes:
- List: bulk-format flag (To create a export with "bundle_key,bundle_name,storage_space,claimed" format)
- Download: cur-dir flag (For not creating a new directory for each bundle, only creating for items)
- Download: use &[String] instead of Vec<String> to pass format
- Some extra changes due to LSP warnings (example: src/util.rs return line)

Additions:
- Bulk-Download: use file as input, iterate the contents, executing the Download command internally.
- open_dir function, to open directory without creating it